### PR TITLE
Seyoung1109

### DIFF
--- a/rur/config.py
+++ b/rur/config.py
@@ -45,7 +45,7 @@ sinkprop_glob = 'sink_[0-9][0-9][0-9][0-9][0-9].dat'
 info_format = {
     'ng': 'info.txt',
 }
-info_format.update(dict.fromkeys(['nh', 'nh_dm_only', 'none', 'hagn', 'yzics', 'yzics_dm_only', 'iap', 'gem', 'fornax', 'y2', 'y3', 'y4', 'nc'], 'info_{snap.iout:05d}.txt'))
+info_format.update(dict.fromkeys(['nh', 'nh_dm_only', 'none', 'hagn', 'yzics', 'yzics_dm_only', 'iap', 'gem', 'fornax', 'y2', 'y3', 'y4', 'nc', 'nh2'], 'info_{snap.iout:05d}.txt'))
 
 data_format = {
     'ng': '{{type}}.out{{icpu:05d}}',
@@ -53,7 +53,7 @@ data_format = {
 
 sinkprop_format = 'sink_{icoarse:05d}.dat'
 
-data_format.update(dict.fromkeys(['nh', 'nh_dm_only', 'none', 'hagn', 'yzics', 'yzics_dm_only', 'iap', 'gem', 'fornax', 'y2', 'y3', 'y4', 'nc'], '{{type}}_{snap.iout:05d}.out{{icpu:05d}}'))
+data_format.update(dict.fromkeys(['nh', 'nh_dm_only', 'none', 'hagn', 'yzics', 'yzics_dm_only', 'iap', 'gem', 'fornax', 'y2', 'y3', 'y4', 'nc', 'nh2'], '{{type}}_{snap.iout:05d}.out{{icpu:05d}}'))
 
 default = [('x', 'f8'), ('y', 'f8'), ('z', 'f8'), ('vx', 'f8'), ('vy', 'f8'), ('vz', 'f8'), ('m', 'f8')]
 
@@ -82,6 +82,12 @@ part_dtype = {
                      ('id', 'i4'), ('level', 'i4'), ('cpu', 'i4'), ('partp', 'i4'),
                      ('family', 'i1'), ('tag', 'i1')],
     'y4': default + [('epoch', 'f8'), ('metal', 'f8'), ('m0', 'f8'),
+                     ('H', 'f8'), ('O', 'f8'), ('Fe', 'f8'), ('Mg', 'f8'),
+                     ('C', 'f8'), ('N', 'f8'), ('Si', 'f8'), ('S', 'f8'), ('D', 'f8'),
+                     ('rho0', 'f8'),
+                     ('id', 'i4'), ('level', 'i4'), ('cpu', 'i4'), ('partp', 'i4'),
+                     ('family', 'i1'), ('tag', 'i1')],
+    'nh2': default + [('epoch', 'f8'), ('metal', 'f8'), ('m0', 'f8'),
                      ('H', 'f8'), ('O', 'f8'), ('Fe', 'f8'), ('Mg', 'f8'),
                      ('C', 'f8'), ('N', 'f8'), ('Si', 'f8'), ('S', 'f8'), ('D', 'f8'),
                      ('rho0', 'f8'),
@@ -158,6 +164,7 @@ hydro_names = {
     'y2': ['rho', 'vx', 'vy', 'vz', 'P', 'metal', 'H', 'O', 'Fe', 'Mg', 'C', 'N', 'Si', 'S', 'dust', 'refmask'],
     'y3': ['rho', 'vx', 'vy', 'vz', 'P', 'metal', 'H', 'O', 'Fe', 'Mg', 'C', 'N', 'Si', 'S', 'refmask'],
     'y4': ['rho', 'vx', 'vy', 'vz', 'P', 'metal', 'H', 'O', 'Fe', 'Mg', 'C', 'N', 'Si', 'S', 'D', 'refmask'],
+    'nh2': ['rho', 'vx', 'vy', 'vz', 'P', 'metal', 'H', 'O', 'Fe', 'Mg', 'C', 'N', 'Si', 'S', 'D', 'refmask'],
     'nc': ['rho', 'vx', 'vy', 'vz', 'P', 'metal', 'H', 'O', 'Fe', 'Mg', 'C', 'N', 'Si', 'S', 'D', 'd1', 'd2', 'd3', 'd4', 'refmask', 'sigma'],
     'ng': ['rho', 'vx', 'vy', 'vz', 'P'],
 }

--- a/rur/utool.py
+++ b/rur/utool.py
@@ -49,10 +49,11 @@ class Table:
         self.table = table
         self.snap = snap
         self.ptype = ptype
-        
+
     def __getitem__(self, item):
         pass
-
+    def __len__(self):
+        return len(self.table)
     def __str__(self):
         return self.table.__str__()
     def __repr__(self):


### PR DESCRIPTION
- add `__len__` in table object
- add mode `nh2` in config.py and uri.py
- add static function `findhalo_NH_pair` in uhmi.HaloMaker

## Function example:
### If I want to find pair of (NH ID1477 at 748) in NH2
`>>> from rur import uhmi`
`>>> jout, halo_ids, rates = uhmi.HaloMaker.findhalo_NH_pair(1477, 748, base='nh')`
(No specified iout of NH2 ... Auto finding ...)
Given: NH halo(1477) at 748(a=0.6868) <-> Find: NH2 halo(?) at 600(a=0.6867)
(No specified particle IDs ... Auto finding ...)
Age of the universe (now/z=0): 9.016 / 13.741 Gyr, z = 0.45611 (a = 0.6868)
No tree_brick file found, or no halo found in /storage6/NewHorizon/halo/DM
(Find tree bricks in 'halo_iap' ...)
Age of the universe (now/z=0): 9.016 / 13.741 Gyr, z = 0.45614 (a = 0.6867)
3 halos are found!
`>>> print(jout)`
600
`>>> print(halo_ids)`
[ 1427 23311 23350]
`>>> print(rates)`
[0.62333821 0.15785631 0.01065814]
### If find pair of (NH2 ID1427 at 600) in NH
`>>> jout, halo_ids, rates = uhmi.HaloMaker.findhalo_NH_pair(1427, 600, base='nh2')`
(No specified iout of NH ... Auto finding ...)
Given: NH2 halo(1427) at 600(a=0.6867) <-> Find: NH halo(?) at 748(a=0.6868)
(No specified particle IDs ... Auto finding ...)
Age of the universe (now/z=0): 9.016 / 13.741 Gyr, z = 0.45614 (a = 0.6867)
Age of the universe (now/z=0): 9.016 / 13.741 Gyr, z = 0.45611 (a = 0.6868)
No tree_brick file found, or no halo found in /storage6/NewHorizon/halo/DM
(Find tree bricks in 'halo_iap' ...)
2 halos are found!
`>>> print(jout)`
600
`>>> print(halo_ids)`
[ 1477, 22679]
`>>> print(rates)`
0.84316801, 0.01535166]