### PR TITLE
Optimization

### DIFF
--- a/rur/config.py
+++ b/rur/config.py
@@ -30,7 +30,7 @@ if type_of_script() == 'jupyter':
 else:
     from tqdm import tqdm
 
-
+defnone = lambda:None
 class Table:
     """
     Table class to store RAMSES particle/AMR data.
@@ -44,7 +44,7 @@ class Table:
         if units is None:
             units = {}
         # unit of table data in dict form, returns 'None' by default, which indicates code unit
-        self.units = defaultdict(lambda: None)
+        self.units = defaultdict(defnone)
         self.units.update(units)
 
     def __getitem__(self, item, return_code_unit=False):

--- a/rur/uhmi.py
+++ b/rur/uhmi.py
@@ -204,6 +204,7 @@ class HaloMaker:
             part_ids = readh.part_ids
             if(copy_part_id):
                 part_ids = part_ids.copy()
+                readh.close()
             return array, part_ids
         else:
             return array

--- a/rur/uri.py
+++ b/rur/uri.py
@@ -1014,7 +1014,7 @@ dtype((numpy.record, [('x', '<f8'), ('y', '<f8'), ('z', '<f8'), ('rho', '<f8'), 
             if(legacy):
                 pass
             else:
-                signal.signal(signal.SIGTERM, self.terminate)
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
                 with Pool(processes=nthread) as pool:
                     results = pool.starmap(_calc_npart, [(filename,kwargs) for filename in files])
                 results = np.asarray(results, dtype=[("mask", object), ("size", int)])
@@ -1204,7 +1204,7 @@ dtype((numpy.record, [('x', '<f8'), ('y', '<f8'), ('z', '<f8'), ('rho', '<f8'), 
                 ncell_tot=None; cell=None
             else:
                 files = [f"{self.snap_path}/output_{self.iout:05d}/amr_{self.iout:05d}.out{icpu:05d}" for icpu in cpulist]
-                signal.signal(signal.SIGTERM, self.terminate)
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
                 with Pool(processes=nthread) as pool:
                     sizes = pool.starmap(_calc_ncell, [(fname,amr_kwargs) for fname in files])
                 signal.signal(signal.SIGTERM, self.terminate)


### PR DESCRIPTION
**Problem 1)**
When `read_cell` with existing `cell_dat`a, it unlinks shared memory so `cell_data` is disrupted.
**Solution)**
Do not unlink and close, but add `flush` function

**Problem 2)**
`flush` is not called automatically
**Solution)**
Using `atexit`, `flush` is automatically reserved when `__init__`, so when code is successfully finished (even if there is an error), `flush` is called.
Using `signal`, if python code is interrupted (Ctrl+c, SIGTERM, broken pipe..), python automatically catches the signal and execute `flush`.

**Limitation?**
It cannot catch the `SIGKILL`. However, when I tested, it doesn't occupy the memory even if terminated by `SIGKILL` (checked by `free -h` and `ls /dev/shm`)